### PR TITLE
Added 'placeholder' property

### DIFF
--- a/src/components/TrixVueWysiwyg.vue
+++ b/src/components/TrixVueWysiwyg.vue
@@ -19,6 +19,7 @@
                      @trix-attachment-add="acceptImage"
                      ref="trix"
                      :input="uniqueId"
+                     :placeholder="placeholder"
         ></trix-editor>
         <input type="hidden" :id="uniqueId" name="content">
     </div>
@@ -45,6 +46,13 @@ export default {
     uniqueId: {
       type: String,
       default: "dd-trix-input"
+    },
+    placeholder: {
+      type: String,
+      required: false,
+      default () {
+        return ''
+      }
     },
     imageUploadPath: {
       type: String


### PR DESCRIPTION
Placeholders are supported by the trix editor: https://github.com/basecamp/trix#creating-an-editor

> Like an HTML textarea, trix-editor accepts autofocus and placeholder attributes.

Thanks for the great component by the way! 😄